### PR TITLE
#54 nessus importer improvements

### DIFF
--- a/serpico.rb
+++ b/serpico.rb
@@ -1347,16 +1347,16 @@ post '/report/:id/findings_add' do
     # if we have hosts add them to the findings too
     params[:finding].each do |number|
         @findingnum = "finding#{number}"
-        @hosts = params["#{@findingnum}"]
+        if params["#{@findingnum}"] != nil
+            @hosts = params["#{@findingnum}"]
 
-        #TODO: merge with existing hosts (if any)
-        finding = Findings.first(:report_id => id, :master_id => number.to_i)
-        #TODO: this is dirty
-        @hosts = "<paragraph>" + @hosts.gsub!(/\[/,'').gsub!(/\]/,'').gsub!(/\"/,'').gsub!(/\s/,'').gsub!(/\,/,'</paragraph><paragraph>')
-        finding.affected_hosts = @hosts
-        finding.save
-        
-        puts "findings for hosts #{finding.affected_hosts}"
+            #TODO: merge with existing hosts (if any)
+            finding = Findings.first(:report_id => id, :master_id => number.to_i)
+            #TODO: this is dirty
+            @hosts = "<paragraph>" + @hosts.gsub!(/\[/,'').gsub!(/\]/,'').gsub!(/\"/,'').gsub!(/\s/,'').gsub!(/\,/,'</paragraph><paragraph>')
+            finding.affected_hosts = @hosts
+            finding.save
+        end
     end
 
     if(config_options["dread"])

--- a/serpico.rb
+++ b/serpico.rb
@@ -1330,7 +1330,9 @@ post '/report/:id/findings_add' do
         return "No Such Report"
     end
 
-	redirect to("/report/#{id}/findings") unless params[:finding]
+    hosts = ""
+	
+    redirect to("/report/#{id}/findings") unless params[:finding]
     
 	params[:finding].each do |finding|
 		templated_finding = TemplateFindings.first(:id => finding.to_i)
@@ -1346,16 +1348,19 @@ post '/report/:id/findings_add' do
     
     # if we have hosts add them to the findings too
     params[:finding].each do |number|
+        # if there are hosts to add with a finding they'll have a param syntax of "findingXXX=ip1,ip2,ip3"
         @findingnum = "finding#{number}"
-        #TODO: merge with existing hosts (if any)
+        #TODO: merge with existing hosts (if any) probably should handle this host stuff in the db
         finding = Findings.first(:report_id => id, :master_id => number.to_i)
-        
+
         if (params["#{@findingnum}"] != nil)
-            @hosts = params["#{@findingnum}"]
-            puts @hosts
-            #TODO: this is dirty
-            @hosts = "<paragraph>" + @hosts.gsub!(/\[/,'').gsub!(/\]/,'').gsub!(/\"/,'').gsub!(/\s/,'').gsub!(/\,/,'</paragraph><paragraph>')
-            finding.affected_hosts = @hosts
+            params["#{@findingnum}"].split(",").each do |ip|
+                #TODO: this is dirty. also should support different delimeters instead of just newline
+                hosts << "<paragraph>" + ip.to_s + "</paragraph>"
+            end
+
+            finding.affected_hosts = hosts
+            hosts = ""
         end
         finding.save
     end

--- a/serpico.rb
+++ b/serpico.rb
@@ -869,7 +869,7 @@ post '/report/:id/import_nessus' do
             end
         end
     end
-    puts "hash: #{autoadd_hosts}"
+
     add_findings = add_findings.uniq
 
     if add_findings.size == 0
@@ -1347,16 +1347,17 @@ post '/report/:id/findings_add' do
     # if we have hosts add them to the findings too
     params[:finding].each do |number|
         @findingnum = "finding#{number}"
-        if params["#{@findingnum}"] != nil
+        #TODO: merge with existing hosts (if any)
+        finding = Findings.first(:report_id => id, :master_id => number.to_i)
+        
+        if (params["#{@findingnum}"] != nil)
             @hosts = params["#{@findingnum}"]
-
-            #TODO: merge with existing hosts (if any)
-            finding = Findings.first(:report_id => id, :master_id => number.to_i)
+            puts @hosts
             #TODO: this is dirty
             @hosts = "<paragraph>" + @hosts.gsub!(/\[/,'').gsub!(/\]/,'').gsub!(/\"/,'').gsub!(/\s/,'').gsub!(/\,/,'</paragraph><paragraph>')
             finding.affected_hosts = @hosts
-            finding.save
         end
+        finding.save
     end
 
     if(config_options["dread"])

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -19,8 +19,13 @@
       %label{ :class => "control-label", :for => "type" } Finding Type
       .controls
         %select{ :name => "type" }
-          - options.finding_types.each do |type|
+          - options.finding_types.each do |type|  
             %option #{type}
+    - if @nessusmap
+      .control-group
+        %label{ :class => "control-label", :for => "pluginid" } Add new nessus ID mapping
+        .controls
+          %input{ :type => 'text', :name => 'pluginid'}
     - if @dread
       .control-group
         %label{ :class => "control-label", :for => "damage" } Damage

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -115,10 +115,11 @@
       %label{ :class => "control-label", :for => "poc" } Proof of Concept
       .controls
         %textarea{ :rows => '10', :class => 'input-xxlarge', :id => 'poc', :name => 'poc'}
-    .control-group
-      %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts
-      .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :id => 'affected_hosts', :name => 'affected_hosts'}
+    - if !@master
+      .control-group
+        %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts
+        .controls
+          %textarea{ :rows => '10', :class => 'input-xxlarge', :id => 'affected_hosts', :name => 'affected_hosts'}
     .control-group
       %label{ :class => "control-label", :for => "remediation" } Remediation
       .controls

--- a/views/findings_add.haml
+++ b/views/findings_add.haml
@@ -2,9 +2,14 @@
   %br
   %br
     - if @findings
-      %h3 Templated Findings
-      %h4 
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Add findings from the template database to your report.
+      - if @autoadd
+        %h3 Auto Add Findings
+        %h4 
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The following findings were automatically selected to be added to your report.
+      - else
+        %h3 Templated Findings
+        %h4 
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Add findings from the template database to your report.
       %br
       &nbsp;
       %input{:type => "text", :class=>"form-control", :placeholder=>"Finding Name Search", :id=>"search"}
@@ -20,7 +25,7 @@
         }
         searchStyle.innerHTML = ".searchable:not([data-index*=\"" + this.value.toLowerCase().replace(/</g, '&rt;').replace(/>/g, '&lt;').replace(/"/g, '&quot;') + "\"]) { display: none; }";
         });
-      %form{:method => 'post'}
+      %form{:method => 'post', :action => "/report/#{@report.id}/findings_add"}
         .table
           %table{:style => 'width: 90%'}
             %tbody
@@ -42,12 +47,27 @@
                             - if finding.type == type
                               %tr
                                 %td{:style => 'width: 80%', :"data-index" => "#{finding.title.downcase.gsub(' ','')}", :class=>"searchable"}
-                                  %input{ :type => "checkbox", :name => "finding[]", :value => "#{finding.id}"}
+                                  - if @autoadd
+                                    - if @autoadd_findings.include?(finding.id.to_s) and not @dup_findings.include?(finding.id)
+                                      %input{ :type => "checkbox", :name => "finding[]", :value => "#{finding.id}", :checked => ""}
+                                    - else
+                                      %input{ :type => "checkbox", :name => "finding[]", :value => "#{finding.id}"}
+                                  - else
+                                    %input{ :type => "checkbox", :name => "finding[]", :value => "#{finding.id}"}
                                   #{finding.title}
+                                  - if @dup_findings
+                                    - if @dup_findings.include?(finding.id)
+                                      .label.label-warning Duplicate
                                   - if finding.overview
                                     %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_#{finding.id}", :id=>"actionButton"}
                                     .info{ :id => "info_#{finding.id}", :class => "collapse out" }
-                                      #{finding.overview.gsub("<paragraph>","<br />").gsub("</paragraph>","").gsub("<bullet>","&#x2022;").gsub("</bullet>","")}                                           
+                                      #{finding.overview.gsub("<paragraph>","<br />").gsub("</paragraph>","").gsub("<bullet>","&#x2022;").gsub("</bullet>","")}
+                                    - if @autoadd_hosts
+                                      - @autoadd_hosts.keys.each do |x|
+                                        - if finding.id == x.to_i
+                                          - @autoadd_hosts[x].each do |ip|
+                                            .label.label-default #{ip}
+                                          %input{ :type => "hidden", :name => "finding#{finding.id.to_s}", :value => "#{@autoadd_hosts[x]}"}
                                 %td{:style => 'width: 20%', :"data-index" => "#{finding.title.downcase.gsub(' ','')}", :class=>"searchable"}
                                   - if @master
                                     %a{ :class => "btn btn-warning", :href => "/master/findings/#{finding.id}/edit"}
@@ -58,6 +78,7 @@
                                     %a{ :class => "btn btn-info", :href => "/master/findings/#{finding.id}/preview"}
                                       %i{:class => 'icon-play-circle icon-white', :title => 'Preview'}
         %input{ :type => "submit", :value => 'Add' }
-        %button{:value => 'Cancel'} Cancel
+        %a{ :href => "/report/#{@report.id}/findings"}
+          %input{ :type => "button", :value => 'Cancel'}
     - else
       No Findings Available

--- a/views/findings_add.haml
+++ b/views/findings_add.haml
@@ -67,7 +67,8 @@
                                         - if finding.id == x.to_i
                                           - @autoadd_hosts[x].each do |ip|
                                             .label.label-default #{ip}
-                                          %input{ :type => "hidden", :name => "finding#{finding.id.to_s}", :value => "#{@autoadd_hosts[x]}"}
+                                          - iplist = @autoadd_hosts[x].join(",")
+                                          %input{ :type => "hidden", :name => "finding#{finding.id.to_s}", :value => "#{iplist}"}
                                 %td{:style => 'width: 20%', :"data-index" => "#{finding.title.downcase.gsub(' ','')}", :class=>"searchable"}
                                   - if @master
                                     %a{ :class => "btn btn-warning", :href => "/master/findings/#{finding.id}/edit"}

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -169,13 +169,14 @@
           - if @finding
             - if @finding.poc
               #{meta_markup(@finding.poc)}
-    .control-group
-      %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts
-      .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'affected_hosts'}
-          - if @finding
-            - if @finding.affected_hosts
-              #{meta_markup(@finding.affected_hosts)}
+    - if !@master
+      .control-group
+        %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts/URLs
+        .controls
+          %textarea{ :rows => '3', :class => 'input-xxlarge', :name => 'affected_hosts'}
+            - if @finding
+              - if @finding.affected_hosts
+                #{meta_markup(@finding.affected_hosts)}
     .control-group
       %label{ :class => "control-label", :for => "remediation" } Remediation
       .controls

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -32,11 +32,17 @@
         .control-group
           %label{ :class => "control-label", :for => "existingnessusmaps" } Nessus IDs Mapped to this finding
           .controls
-            - @nessus.each do |item|
-              - if item.pluginid
-                #{item.pluginid}
-                %br
-          %br
+            .table
+              %table{ :style => 'width: 220px'}
+                %tbody
+                - @nessus.each do |item|
+                  - if item.pluginid
+                    %tr
+                      %td
+                        #{item.pluginid}
+                      %td{ :align => "right"}
+                        %a{ :class => "btn btn-danger btn-xs", :href => "/mapping/#{@finding.id}/nessus/#{item.pluginid}/delete"}
+                          %i{:class => 'icon-remove icon-white', :value => "#{item.pluginid}", :type => "submit", :title => 'Delete'}
         .control-group
           %label{ :class => "control-label", :for => "pluginid" } Add new nessus ID mapping
           .controls

--- a/views/findings_list.haml
+++ b/views/findings_list.haml
@@ -33,10 +33,6 @@
                                 %tr{:class => "#{@class}"}
                                   %td{:style => 'width: 70%'}
                                     #{finding.title} 
-                                    - if finding.overview
-                                      %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_#{finding.id}", :id=>"actionButton"}
-                                      .info{ :id => "info_#{finding.id}", :class => "collapse out" }
-                                        #{finding.overview.gsub("<paragraph>","<br/>").gsub("</paragraph>","").gsub("<bullet>","&#x2022;").gsub("</bullet>","")}
                                   - if @dread
                                     %td{:style => 'width: 10%'}
                                       #{finding.dread_total}

--- a/views/import_nessus.haml
+++ b/views/import_nessus.haml
@@ -1,22 +1,25 @@
 .span10
-  %form{:method => 'post', :enctype=>"multipart/form-data"}
-    %br
-    %h2 Auto Add Findings from Nessus XML
-    %br
-    %table
-      %tr
-      %tr
-        %td
-          Upload Nessus XML File (Nessusv2 only).&nbsp;
-          %br
-          %br
-          %input{:type => 'file', :name => 'file'}
-      %tr
-        %td
-          %br
-    %br
-    %br
-    %input{:type => 'submit', :value => 'Upload' }
-    %button{:value => 'Cancel'} Cancel
+  - if not @nessusmap
+    Nessus Auto Mapping not enabled. Contact your administrator to enable.
+  - else
+    %form{:method => 'post', :enctype=>"multipart/form-data"}
+      %br
+      %h2 Auto Add Findings from Nessus XML
+      %br
+      %table
+        %tr
+        %tr
+          %td
+            Upload Nessus XML File (Nessusv2 only).&nbsp;
+            %br
+            %br
+            %input{:type => 'file', :name => 'file'}
+        %tr
+          %td
+            %br
+      %br
+      %br
+      %input{:type => 'submit', :value => 'Upload' }
+      %button{:value => 'Cancel'} Cancel
 
 


### PR DESCRIPTION
this feature allows the user to pick and choose which auto mapped findings to add to the report after parsing the nessus xml file. It also will add the affected hosts automatically and provides the user a preview of those hosts prior to adding the finding. It also detects findings that are already added to the report and labels them as duplicate and defaults to not adding the finding.

![auto_add_findings](https://cloud.githubusercontent.com/assets/1406479/7940429/59111eb2-0916-11e5-8627-7d930358537d.jpg)


