### PR TITLE
add support for HTTP-only servers

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
     "port":"8443",
+    "use_ssl":true,
+    "bind_address":"0.0.0.0",
     "ssl_certificate":"./cert.pem",
     "ssl_key":"key.pem",
     "ldap":"false",

--- a/helpers/sinatra_ssl.rb
+++ b/helpers/sinatra_ssl.rb
@@ -7,17 +7,19 @@ require 'openssl'
 module Sinatra
   class Application
     def self.run!
-      certificate_content = File.open(ssl_certificate).read
-      key_content = File.open(ssl_key).read
-
       server_options = {
         :Port => port,
-        :SSLEnable => true,
-        :SSLCertificate => OpenSSL::X509::Certificate.new(certificate_content),
-        :SSLPrivateKey => OpenSSL::PKey::RSA.new(key_content),
-        :SSLVerifyClient    => OpenSSL::SSL::VERIFY_NONE
+        :SSLEnable => use_ssl,
+        :BindAddress => bind_address,
       }
-
+      if (use_ssl) then
+        certificate_content = File.open(ssl_certificate).read
+        key_content = File.open(ssl_key).read
+        server_options[:SSLCertificate] = OpenSSL::X509::Certificate.new(certificate_content)
+        server_options[:SSLPrivateKey] = OpenSSL::PKey::RSA.new(key_content)
+        server_options[:SSLVerifyClient] = OpenSSL::SSL::VERIFY_NONE
+      end
+      
       Rack::Handler::WEBrick.run self, server_options do |server|
         [:INT, :TERM].each { |sig| trap(sig) { server.stop } }
         server.threaded = settings.threaded if server.respond_to? :threaded=

--- a/serpico.rb
+++ b/serpico.rb
@@ -21,8 +21,9 @@ config_options = JSON.parse(File.read('./config.json'))
 ## SSL Settings
 set :ssl_certificate, config_options["ssl_certificate"]
 set :ssl_key, config_options["ssl_key"]
+set :use_ssl, config_options["use_ssl"]
 set :port, config_options["port"]
-set :bind, "0.0.0.0"
+set :bind_address, config_options["bind_address"]
 
 ## Global variables
 set :finding_types, config_options["finding_types"]


### PR DESCRIPTION
The default configuration makes it impossible to run Serpico on localhost with a reverse proxy. This patch makes it possible to bind on loopback only, and without TLS.

Gotcha: have your reverse proxy rewrite the HTTP_Referer: header or else authentication will fail with no warning message.